### PR TITLE
Rocket league Stats

### DIFF
--- a/commands/rocket-league-stats.js
+++ b/commands/rocket-league-stats.js
@@ -21,12 +21,13 @@ module.exports.run = async (bot, message, args) => {
   }
 
   async function getPlayerStats(platformId, username, rlApi){
-    console.log(username)
-    console.log(platformId)
-    console.log(rlApi)
     let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}`).set('Authorization', rlApi);
-    
-    console.log(body);
+
+    let embed = new Discord.RichEmbed()
+      .setColor("#4286f4")
+      .setTitle(`## ROCKET LEAGUE STATS FOR ${body.displayName.toUpperCase()} ##`)
+      .setImage(body.signatureUrl);
+    return message.channel.send(embed);
   }
 
 

--- a/commands/rocket-league-stats.js
+++ b/commands/rocket-league-stats.js
@@ -4,31 +4,28 @@ const superagent = require('superagent');
 const rlApi = config.rlApi;
 
 module.exports.run = async (bot, message, args) => {
-  let platform = args[0].toLowerCase();
+  if(!args[0])
+    return message.channel.send("Error. Make sure you specify a platform. `!rl [platform pc/psn/xbl] <id>`\n**<id>** is your STEAMID64/PSN Username/XboxGamerTag.");
+  if (!args[1])
+    return message.channel.send("Error. Make sure you specify an user id. `!rl [platform pc/psn/xbl] <id>`\n**<id>** is your STEAMID64/PSN Username/XboxGamerTag.");
   let username = args[1];
+  
+  if(args[0].toLowerCase() == 'steam' || args[0].toLowerCase() == 'pc'){
+    let platformId = '1';
+    getPlayerStats(platformId, username, rlApi);
 
-  getPlatformId(platform, rlApi);
-  getPlayerStats(platform, username, rlApi);
-
-  async function getPlatformId(platform, rlApi) {
-    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/data/platforms?apikey=${rlApi}`);
-    return {
-      steam: body[0],
-      psn: body[1],
-      xbl: body[2]
-    }
+  }else if(args[0].toLowerCase() == 'psn' || args[0].toLowerCase() == 'ps4'){
+    let platformId = '2';
+  }else if(args[0].toLowerCase() == 'xbl' || args[0].toLowerCase() == 'xboxone' || args[0].toLowerCase() == 'xbox'){
+    let platformId = '3';
   }
 
-  async function getPlayerStats(platform, username, rlApi){
-    let platformData = await getPlatformId(platform, rlApi);
-   // console.log(platformData);
-    for(let i = 0; i < 3; i++){
-      console.log(i);
-      if(platform == platformData[Object.keys(platformData)[i]].name.toLowerCase()){
-        let platformId = platformData[Object.keys(platformData)[i]].id;
-      }
-    }
-    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}?apikey=${rlApi}`);
+  async function getPlayerStats(platformId, username, rlApi){
+    console.log(username)
+    console.log(platformId)
+    console.log(rlApi)
+    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}`).set('Authorization', rlApi);
+    
     console.log(body);
   }
 

--- a/commands/rocket-league-stats.js
+++ b/commands/rocket-league-stats.js
@@ -4,8 +4,42 @@ const superagent = require('superagent');
 const rlApi = config.rlApi;
 
 module.exports.run = async (bot, message, args) => {
-  let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/data/platforms?apikey=${rlApi}`);
- console.log(body);
+  let platform = args[0].toLowerCase();
+  let username = args[1];
+
+  getPlatformId(platform, rlApi);
+  getPlayerStats(platform, username, rlApi);
+
+  async function getPlatformId(platform, rlApi) {
+    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/data/platforms?apikey=${rlApi}`);
+    return {
+      steam: body[0],
+      psn: body[1],
+      xbl: body[2]
+    }
+  }
+
+  async function getPlayerStats(platform, username, rlApi){
+    let platformData = await getPlatformId(platform, rlApi);
+   // console.log(platformData);
+    for(let i = 0; i < 3; i++){
+      console.log(i);
+      if(platform == platformData[Object.keys(platformData)[i]].name.toLowerCase()){
+        let platformId = platformData[Object.keys(platformData)[i]].id;
+      }
+    }
+    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}?apikey=${rlApi}`);
+    console.log(body);
+  }
+
+
+ //link command
+ //!rl link <platform> [id] ~ stores 
+ //message.author.tag
+ //stores in db
+ //next time request
+ //get id from db
+ //use api and display stats.
 };
 
 module.exports.help = {

--- a/commands/rocket-league-stats.js
+++ b/commands/rocket-league-stats.js
@@ -13,15 +13,18 @@ module.exports.run = async (bot, message, args) => {
   if(args[0].toLowerCase() == 'steam' || args[0].toLowerCase() == 'pc'){
     let platformId = '1';
     getPlayerStats(platformId, username, rlApi);
-
   }else if(args[0].toLowerCase() == 'psn' || args[0].toLowerCase() == 'ps4'){
     let platformId = '2';
+    getPlayerStats(platformId, username, rlApi);
   }else if(args[0].toLowerCase() == 'xbl' || args[0].toLowerCase() == 'xboxone' || args[0].toLowerCase() == 'xbox'){
     let platformId = '3';
+    getPlayerStats(platformId, username, rlApi);
   }
 
   async function getPlayerStats(platformId, username, rlApi){
-    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}`).set('Authorization', rlApi);
+    let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/player?unique_id=${username}&platform_id=${platformId}`).set('Authorization', rlApi).on('error', err => {
+      return message.channel.send('Error Occurred. Make sure you got the syntax right. `!rl [platform pc/psn/xbl] <id>`\n**<id>** is your STEAMID64/PSN Username/XboxGamerTag.\n\n**Make sure your profile privacy settings are set to public**');
+     });
 
     let embed = new Discord.RichEmbed()
       .setColor("#4286f4")

--- a/commands/rocket-league-stats.js
+++ b/commands/rocket-league-stats.js
@@ -1,0 +1,13 @@
+const Discord = require("discord.js");
+const config = require("../config.json");
+const superagent = require('superagent');
+const rlApi = config.rlApi;
+
+module.exports.run = async (bot, message, args) => {
+  let { body } = await superagent.get(`https://api.rocketleaguestats.com/v1/data/platforms?apikey=${rlApi}`);
+ console.log(body);
+};
+
+module.exports.help = {
+  name: "rl"
+};

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ bot.on("message", async message => {
     if(commandFile)
         commandFile.run(bot, message, args); //Run commands
 })
-bot.login(config.token);
+bot.login(config.devToken);
 
 function status_change(status){
     setInterval(function(){


### PR DESCRIPTION
Added rocket league game stats. 
`!rl [platform pc/psn/xbl] <id>` 

The <id> is the STEAMID64 for PC users, PSN Username for PS4 users, and XboxGamerTag for XboxOne users.

Fails if profile settings are set to private. (Added in error handling which handles the 'User not found' error thrown from the API)